### PR TITLE
Enable Travis CI for a Rug Archive

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,21 @@
+---
+kind: "operation"
+client: "rug-cli 0.21.4"
+executor:
+  name: "EnableTravisForRugArchive"
+  group: "atomist-rugs"
+  artifact: "travis-editors"
+  version: "0.12.0"
+  origin:
+    repo: "git@github.com:atomist-rugs/travis-editors.git"
+    branch: "master"
+    sha: "678d3e9"
+  parameters:
+    - "owner": "atomist"
+    - "repo": "handlers"
+    - "org": ".org"
+    - "github_token": "3**************************************9"
+    - "maven_base_url": "https://atomist.jfrog.io/atomist"
+    - "maven_user": "t***************y"
+    - "maven_token": "z**************7"
+

--- a/.atomist/build/cli-build.yml
+++ b/.atomist/build/cli-build.yml
@@ -1,0 +1,16 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-release:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/rugs-release"

--- a/.atomist/build/cli-dev.yml
+++ b/.atomist/build/cli-dev.yml
@@ -1,0 +1,19 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-dev:
+    publish: true
+    url: "${MAVEN_BASE_URL}/rugs-dev"
+    authentication:
+      username: "${MAVEN_USER}"
+      password: "${MAVEN_TOKEN}"

--- a/.atomist/build/cli-release.yml
+++ b/.atomist/build/cli-release.yml
@@ -1,0 +1,19 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-release:
+    publish: true
+    url: "${MAVEN_BASE_URL}/rugs-release"
+    authentication:
+      username: "${MAVEN_USER}"
+      password: "${MAVEN_TOKEN}"

--- a/.atomist/build/travis-build.bash
+++ b/.atomist/build/travis-build.bash
@@ -1,0 +1,162 @@
+#!/bin/bash
+# test and publish rug archive
+
+set -o pipefail
+
+declare Pkg=travis-build
+declare Version=0.3.0
+
+function msg() {
+    echo "$Pkg: $*"
+}
+
+function err() {
+    msg "$*" 1>&2
+}
+
+# usage: main "$@"
+function main () {
+    local formula_url=https://raw.githubusercontent.com/atomist/homebrew-tap/master/Formula/rug-cli.rb
+    local formula
+    formula=$(curl -s -f "$formula_url")
+    if [[ $? -ne 0 || ! $formula ]]; then
+        err "failed to download homebrew formula $formula_url: $formula"
+        return 1
+    fi
+
+    local version
+    version=$(echo "$formula" | sed -n '/^ *url /s,.*/\([0-9]*\.[0-9]*\.[0-9]*\)/.*,\1,p')
+    if [[ $? -ne 0 || ! $version ]]; then
+        err "failed to parse brew formula for version: $version"
+        err "$formula"
+        return 1
+    fi
+    msg "rug CLI version: $version"
+
+    local rug=$HOME/.atomist/rug-cli-$version/bin/rug
+    if [[ ! -x $rug ]]; then
+        msg "downloading rug CLI"
+        if ! mkdir -p "$HOME/.atomist"; then
+            err "failed to make ~/.atomist directory"
+            return 1
+        fi
+
+        local rug_cli_url=https://github.com/atomist/rug-cli/releases/download/$version/rug-cli-$version-bin.tar.gz
+        local rug_cli_tgz=$HOME/.atomist/rug-cli-$version.tar.gz
+        if ! curl -s -f -L -o "$rug_cli_tgz" "$rug_cli_url"; then
+            err "failed to download rug CLI from $rug_cli_url"
+            return 1
+        fi
+
+        if ! tar -xzf "$rug_cli_tgz" -C "$HOME/.atomist"; then
+            err "failed to extract rug CLI archive"
+            return 1
+        fi
+    fi
+    rug="$rug -qurX"
+
+    local build_dir=.atomist/build
+    local cli_user=$HOME/.atomist/cli.yml
+    if ! install --mode=0600 "$build_dir/cli-build.yml" "$cli_user"; then
+        err "failed to install build cli.yml"
+        return 1
+    fi
+    trap "rm -f $cli_user" RETURN
+
+    if [[ -f .atomist/package.json ]]; then
+        msg "running npm install"
+        if ! ( cd .atomist && npm install ); then
+            err "npm install failed"
+            return 1
+        fi
+    fi
+
+    msg "running tests"
+    if ! $rug test; then
+        err "rug test failed"
+        return 1
+    fi
+
+    msg "installing archive"
+    if ! $rug install; then
+        err "rug install failed"
+        return 1
+    fi
+
+    [[ $TRAVIS_PULL_REQUEST == false ]] || return 0
+
+    local archive_version
+    local manifest=.atomist/manifest.yml package=.atomist/package.json
+    if [[ -f $manifest ]]; then
+        archive_version=$(awk -F: '$1 == "version" { print $2 }' "$manifest" | sed 's/[^.0-9]//g')
+    elif [[ -f $package ]]; then
+        archive_version=$(jq --raw-output --exit-status .version "$package")
+    else
+        err "no manifest.yml or package.json in archive"
+        return 1
+    fi
+    if [[ $? -ne 0 || ! $archive_version ]]; then
+        err "failed to extract archive version: $archive_version"
+        return 1
+    fi
+    local project_version cli_yml project_group
+    if [[ $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ $archive_version != $TRAVIS_TAG ]]; then
+            err "archive version ($archive_version) does not match git tag ($TRAVIS_TAG)"
+            return 1
+        fi
+        project_version=$TRAVIS_TAG
+        cli_yml=$build_dir/cli-release.yml
+    else
+        local timestamp
+        timestamp=$(date +%Y%m%d%H%M%S)
+        if [[ $? -ne 0 || ! $timestamp ]]; then
+            err "failed to generate timestamp: $timestamp"
+            return 1
+        fi
+        project_version=$archive_version-$timestamp
+        cli_yml=$build_dir/cli-dev.yml
+    fi
+    project_group=$(echo "$TRAVIS_REPO_SLUG" | sed -n -E 's/(.*)\/.*/\1/p')
+    if [[ $? -ne 0 || ! $project_group ]]; then
+        err "failed to extract archive group: $project_group"
+        return 1
+    fi
+
+    msg "branch: $TRAVIS_BRANCH"
+    msg "archive version: $project_version"
+    msg "archive group: $project_group"
+
+    if [[ $TRAVIS_BRANCH == master || $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if ! install --mode=0600 "$cli_yml" "$cli_user"; then
+            err "failed to install $cli_yml"
+            return 1
+        fi
+
+        msg "publishing archive"
+        if ! $rug publish --archive-version "$project_version" --archive-group "$project_group"; then
+            err "failed to publish archive $project_version"
+            return 1
+        fi
+        if ! git config --global user.email "travis-ci@atomist.com"; then
+            err "failed to set git user email"
+            return 1
+        fi
+        if ! git config --global user.name "Travis CI"; then
+            err "failed to set git user name"
+            return 1
+        fi
+        local git_tag=$project_version+travis$TRAVIS_BUILD_NUMBER
+        if ! git tag "$git_tag" -m "Generated tag from TravisCI build $TRAVIS_BUILD_NUMBER"; then
+            err "failed to create git tag: $git_tag"
+            return 1
+        fi
+        if ! git push --quiet --tags "https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG" > /dev/null 2>&1; then
+            err "failed to push git tags"
+            return 1
+        fi
+    fi
+}
+
+main "$@" || exit 1
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: false
+language: java
+jdk:
+- oraclejdk8
+branches:
+  except:
+  - /\+travis\d+$/
+env:
+  global:
+  - MAVEN_BASE_URL=https://atomist.jfrog.io/atomist
+  - secure: Y3x5oDqDRgS8eaCrR8i5hWOsPSovTW+zyeIIkhPar/0EP7apB7NWgWWbM39MyD/3cYbxZZRFXvn/ZUiEdurYg/EglcOOUCmn0brDOHmZcweXu0xlJ8sRtXxWqC2RMz5oedwAKl+10Df+SHuy68tYF/xcbIa+1oHRHUidr84fwEEk3kN/o6FEdRmVuGFsSFUmbpGto47bul2cc0k0NQ1N3jckh+3wg/waq0n+foJtlwppvb5SFRDQyrFVI4AgVpA2UtxvTuf8EdvlFBd1b2PvrwXicuMtYT8EqYkxSYCtURKEpSVBkTeR9LiujWVAV9pexu3FKraFTc2p3wKyoFjSaCriJje3M40eQLmMAXeufPzrGVgki5pqQXnqq8hqvegLRgEuuooNvps3AtB/JbJVcId3iNJr6QQf+DTBWOHkxPZr0iG0X50ogbelGIojfh6IKM/wNlnbsFyzRLYQt04tVmRa/akH6kQXFgHBTpQ95MoHY8K3Sj6DjpwmP34lE0RVYxIpTh8VXKg3V0R02OOtX3g36o5hsd4xjn6+0eN6zmv2YqGijSW7kjKemgbYSwyOfRk9wa07ya8tnCwb+EAb5xkjXF4mj+bVJZmAcvYImrslpIx4xcYytbe514q6ek17k25C2DkIwgQK/cMZi/CU0k3e5PsddaDans7mJ5m1yAw=
+  - secure: PHdlWg/nYnqT3akGEdem1Z0LNYEyy5aOjE9GWA1QwdIx6W1iqntGTxLnFGPv+sb6mSyIwTG1vhw9hu4Qzj9DxvqtY8AlwVl4GYoOzHCnbVclN7B/m2Pu5LkrnDj5THmHu/LKpeBvZGoYeKwUmvPIQ/JIiGaYnUGv4X7eJYlBDwufEW/I1lGhQIGwfteqf6OOZ8hXqyiOHNKksegiWUr4btp0iBfWwQmOiKMu7kj4O+ROVg7XseQMxYXgzwMTG4G7/kcYdPlr/cqEU9f2lnY3PovGDgzqA8pI9tMZQD3LsrsbM23LBVbkxg3Cn8rkW0hwylmZz0Q52CL8HP/zQnPK732Ri+6irC1CMWbN0M0QCcbZVn61AfhtZRexr18IdP6yp7gZ1SXhxGBeRjHiloXBaTuCytxVRd2ZTNLwSgui0yetQNbja0UGT9iKvvP5z3G2fI+rMB5/79TSXQt0SCNx7OxrSf4QGDPX2eiMJyyme8piA0qn/V0h19Pmx36ZI50WlmhuIIt0Gowb5jfXxL+tL7i3MmsmkHHmDbu9OxWeFwIay217vW2b/Ap9KFx8jaiDQTH0uoISgWbVP1Vua7yFcWveSsKpXDSAvjQRkCn4jQ0rB/rP6Ti7LsR8PNcsStdT+ad0ousqxSyGEbzScqudlS2zOUUitEGbGlafm38QxY0=
+  - secure: hudaFj4SucPFhdnZyWMz41zkCdJo9ETU96gUE0gOSrV1tWZqjlJkRG9cgX4YiwadueHTzIESkgKGVGG396DVsy7S02Pby273Bn1jPUyix1j84koCpW5Xx9J1G+DxcbPVZU4IhFUaGXlN4FaGBwsSd6ed4U6E4ARYjmaoHFnpAlvgD+TkH/OQL/zDrI6Ey8tXJBGhOnoUibiTLw+71EkG4xMizmBSs/Wp/Ook3DTiD1hPUcjjeBU+Zpco/HgWj1+2NzY4UFQFXGJtVxLDxisqScCxnIWiGUq79/CYvPOsbZhTH79QE8Ir/jn5ql6e1DqEvdgnQh9DSvhulmAcPiuEgeMmA1xeTVvO52NKH++ZGExk0jEOHO5JQETAwmsubPHvEUA0fAnNqDiO47fYZ6Imo7kaa6/LAmAmtPtAyCLZFB/sGPWrGNpJ5xFP5UcfGmi/Qftxn9ZCN9UfLK7DAjDCX2A6/cKlTBF3tBkpruIuxjfRiCtxWqOAvc+1aJXlJBAh4KdWBGtzs1tKL9zR5MXiImxeMpX+OsMFabyHDWQno1foTyDinNUGFMKLMHladRlwUa3cF2o4zc5IrXr9lnDUt14wSKAP1JLP//RpssqZJFLgffDI4cArF24R/oJufndj4K/DHTwMrVYLgjIU/J5W0+GQjozAQDsSbBBUkUYsEh4=
+install:
+- nvm install 6.9.2
+script: bash .atomist/build/travis-build.bash
+notifications:
+  email: false
+  webhooks:
+    urls:
+    - https://webhook.atomist.com/travis
+    on_success: always
+    on_failure: always
+    on_start: always
+cache:
+  directories:
+  - $HOME/.atomist


### PR DESCRIPTION
Created by Atomist Executor `EnableTravisForRugArchive`
```
---
kind: "operation"
client: "rug-cli 0.21.4"
executor:
  name: "EnableTravisForRugArchive"
  group: "atomist-rugs"
  artifact: "travis-editors"
  version: "0.12.0"
  origin:
    repo: "git@github.com:atomist-rugs/travis-editors.git"
    branch: "master"
    sha: "678d3e9"
  parameters:
    - "owner": "atomist"
    - "repo": "handlers"
    - "org": ".org"
    - "github_token": "3**************************************9"
    - "maven_base_url": "https://atomist.jfrog.io/atomist"
    - "maven_user": "t***************y"
    - "maven_token": "z**************7"

```